### PR TITLE
Update Version of Deployment Tracker Client

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "async": "^1.5.2",
     "body-parser": "^1.15.1",
-    "cf-deployment-tracker-client": "0.0.8",
+    "cf-deployment-tracker-client": "^0.x",
     "cfenv": "1.0.3",
     "cloudant": "^1.4.1",
     "connect-redis": "^3.0.2",


### PR DESCRIPTION
A new version of the Deployment Tracker client is now available. This new version, `0.1.1`, adds the ability to track bound services and runtime. This pull request updates the version string for `cf-deployment-tracker-client` to `^0.x`. The Deployment Tracker client uses semantic versioning (even in pre-1.0 releases). Rather than simply upgrading to `0.1.1`, this pull request allows for automatic updates when new minor and patch versions are made available. While a caret version range such as `^0.1.1` would be preferable, caret version ranges only allow for patch and minor updates ​for versions `1.0.0` and above.
